### PR TITLE
Improve Linux downloads

### DIFF
--- a/download.html
+++ b/download.html
@@ -86,45 +86,65 @@ permalink: download
                         <li class="links">
                             <a href="https://www.archlinux.org/packages/community/x86_64/keepassxc/">Arch package</a>
                         </li>
+                        <li>
+                            <code># pacman -S keepassxc</code>
+                        </li>
                     </ul>
                 </div>
 
+                <div class="col-md-6">
+                    <h5><i class="fl fl-centos" aria-hidden="true"></i> CentOS</h5>
+                    <ul class="download-links">
+                        <li class="links">
+                            <a href="https://copr.fedorainfracloud.org/coprs/bugzy/keepassxc/">Unofficial CentOS package</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="row">
                 <div class="col-md-6">
                     <h5><i class="fl fl-debian" aria-hidden="true"></i> Debian and Ubuntu</h5>
                     <ul class="download-links">
                         <li class="links">
-                            <a href="https://github.com/magkopian/keepassxc-debian/releases">Unofficial Debian packages</a>
+                            <a href="https://github.com/magkopian/keepassxc-debian/releases">Unofficial Debian package</a>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="col-md-6">
+                    <h5><i class="fl fl-fedora" aria-hidden="true"></i> Fedora</h5>
+                    <ul class="download-links">
+                        <li class="links">
+                            <a href="https://apps.fedoraproject.org/packages/keepassxc">Fedora package</a>
+                        </li>
+                        <li>
+                            <code># dnf install keepassxc</code>
                         </li>
                     </ul>
                 </div>
             </div>
 
             <div class="row">
-                <div class="col-md-6">
-                    <h5><i class="fl fl-fedora" aria-hidden="true"></i> Fedora and CentOS</h5>
-                    <ul class="download-links">
-                        <li class="links">
-                            <a href="https://copr.fedorainfracloud.org/coprs/bugzy/keepassxc/">Unofficial Fedora packages</a>
-                        </li>
-                    </ul>
-                </div>
-
                 <div class="col-md-6">
                     <h5><i class="fl fl-gentoo" aria-hidden="true"></i> Gentoo</h5>
                     <ul class="download-links">
                         <li class="links">
-                            <a href="https://packages.gentoo.org/packages/app-admin/keepassxc">Gentoo ebuilds</a>
+                            <a href="https://packages.gentoo.org/packages/app-admin/keepassxc">Gentoo ebuild</a>
+                        </li>
+                        <li>
+                            <code># emerge app-admin/keepassxc</code>
                         </li>
                     </ul>
                 </div>
-            </div>
-
-            <div class="row">
                 <div class="col-md-6">
                     <h5><i class="fl fl-opensuse" aria-hidden="true"></i> OpenSUSE</h5>
                     <ul class="download-links">
                         <li class="links">
                             <a href="https://software.opensuse.org/package/keepassxc">OpenSUSE package</a>
+                        </li>
+                        <li>
+                            <code># zypper install keepassxc</code>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
- update Fedora to official package
- separate Fedora and CentOS
- add install command line to all official packages
- remove plural from some instances of "packages"

No sudo was used for the examples but instead a hash to indicate root shell as sudo is not necessarily universally available and configured - can be changed to sudo if seen otherwise.