### PR TITLE
Rename 'OS X' to 'macOS' on the Project and Docs pages

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -41,7 +41,7 @@ permalink: docs
             platform integration.
         </dd>
 
-        <dt id="faq-autotype"><a href="#faq-autotype">Is Auto-Type supported on OS X and Windows?</a></dt>
+        <dt id="faq-autotype"><a href="#faq-autotype">Is Auto-Type supported on macOS and Windows?</a></dt>
         <dd>Yes, Auto-Type works on all three supported platforms.</dd>
 
         <dt id="faq-cloudsync"><a href="#faq-cloudsync">Why is there no cloud synchronization feature built into KeePassXC?</a></dt>

--- a/download.html
+++ b/download.html
@@ -12,7 +12,7 @@ permalink: download
     </li>
     <li class="col-md-3">
         <a href="#mac" data-toggle="tab">
-            <span class="platform"><i class="fa fa-apple" aria-hidden="true"></i> OS X</span>
+            <span class="platform"><i class="fa fa-apple" aria-hidden="true"></i> macOS</span>
         </a>
     </li>
     <li class="col-md-3">
@@ -155,7 +155,7 @@ permalink: download
     </div>
 
     <div class="tab-pane active fade in" id="mac">
-        <h3><i class="fa fa-mac" aria-hidden="true"></i> OS X</h3>
+        <h3><i class="fa fa-mac" aria-hidden="true"></i> macOS</h3>
 
         <div class="official-packages">
             <div>
@@ -166,7 +166,7 @@ permalink: download
                 <ul class="download-links">
                     <li class="links">
                         <a href="https://github.com/keepassxreboot/keepassxc/releases/download/{{ site.data.version.stable.mac.dmg }}/KeePassXC-{{ site.data.version.stable.mac.dmg }}.dmg">
-                             Binary bundle for OS X 10.7 and later
+                             Binary bundle for macOS 10.7 and later
                         </a>
                     </li>
                     <li class="links sig">


### PR DESCRIPTION
I noticed that y'all [recently replaced "OS X" with the current name "macOS" on the project page](https://github.com/keepassxreboot/keepassxreboot.github.io/commit/60e1cb2e56a2b63b735a89d267bc34bfc96867f1), so I thought I'd so the same for Downloads and Docs pages. (Note that "macOS" is used on [the Screenshots page](https://keepassxc.org/screenshots) already.)