### PR TITLE
Remove note about KeePassHTTP being weak

### DIFF
--- a/project.html
+++ b/project.html
@@ -35,15 +35,6 @@ permalink: project
     <p> For a full list of new features and changes, have a look at the
         <a href="https://github.com/keepassxreboot/keepassxc/wiki/KeePassXC-Changelog">full KeePassXC changelog</a>.
 
-    <div class="info">
-        <h6>A note about KeePassHTTP</h6>
-        <p>KeePassHTTP is not a highly secure protocol and has certain flaws which allow an attacker to decrypt your
-            passwords if they manage to intercept communication between a KeePassHTTP server and PassIFox/chromeIPass over a
-            network connection (see <a href="https://github.com/pfn/keepasshttp/issues/258">here</a> and <a
-                    href="https://github.com/keepassxreboot/keepassxc/issues/147">here</a>). KeePassXC therefore strictly
-            limits communication between itself and the browser plugin to your local computer. As long as your computer is
-            not compromised, your passwords are fairly safe that way, but use it at your own risk!
-    </div>
 </div>
 
 <div id="requirements">


### PR DESCRIPTION
I am helping to edit a guide to using KeePassXC, and found that the author had inserted a warning: "If your machine is compromised, an attacker can intercept the communication between your browser plug-in and KeePassXC." I believe that was motivated by the warning text here. As noted in https://github.com/pfn/keepasshttp/issues/258 and https://github.com/keepassxreboot/keepassxc/issues/147, communicating via HTTP with localhost is safe, since an attacker who can intercept localhost communications can just read your passwords directly.

Since localhost-only is now the default mode in KeePassHTTP, I think this note just creates confusion and unnecessary fear among users.