### PR TITLE
Fixes some internal website links

### DIFF
--- a/download.html
+++ b/download.html
@@ -319,7 +319,7 @@ permalink: download
                             SHA-256 digest</a>
                     </li>
                     <li class="note">
-                        For installation instructions please read the <a href="docs#wiki">Docs</a>.
+                        For installation instructions please read the <a href="/docs#wiki">Docs</a>.
                     </li>
                 </ul>
             </div>
@@ -328,8 +328,8 @@ permalink: download
 </div>
 
 <div class="info">
-    <h4><a href="verifying-signatures">Verifying signatures</a></h4>
-    <p>Before installing KeePassXC, you should <strong>always</strong> <a href="verifying-signatures">verify</a> that
+    <h4><a href="/verifying-signatures">Verifying signatures</a></h4>
+    <p>Before installing KeePassXC, you should <strong>always</strong> <a href="/verifying-signatures">verify</a> that
         your download matches the signature that is published alongside the release package!
     </p>
 </div>


### PR DESCRIPTION
I think/hope this fixes this issue: https://github.com/keepassxreboot/keepassxc/issues/1449

There could be other links on the site broken in the same way-- don't have extra time to check at the moment, unfortunately. 