### PR TITLE
Update extension and browser migration document URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -335,14 +335,14 @@ title: Documentation and FAQ
         <dd>
             Yes. KeePassXC supports KeePassHTTP-Connector as a legacy browser integration and a newer extension KeePassXC-Browser.
             You can download KeePassXC-Browser for <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/">Mozilla Firefox</a> and
-            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/iopaggbpplllidnfmcghoonnokmjoicf">Google Chrome / Chromium / Vivaldi</a>.
+            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk">Google Chrome / Chromium / Vivaldi</a>.
         </dd>
 
         <dt id="faq-browser-howto"><a href="#faq-browser-howto">How do I connect browser extensions with KeePassXC?</a></dt>
         <dd>
             You can enable Browser Integration (KeePassXC-Browser) or Legacy Browser Integration (KeePassHTTP-Connector) from KeePassXC settings.
             A guide for KeePassHTTP-Connector is available <a href="https://github.com/smorks/keepasshttp-connector/blob/master/documentation/KeePassHttp-Connector.md">
-            here</a>. See the page <a href="https://keepassxc.org/docs/keepassxc-browser-migration.md">How to connect KeePassXC-Browser with KeePassXC</a> for more
+            here</a>. See the page <a href="https://keepassxc.org/docs/keepassxc-browser-migration/">How to connect KeePassXC-Browser with KeePassXC</a> for more
             detailed information for the new Browser Integration.
         </dd>
 

--- a/project.html
+++ b/project.html
@@ -36,7 +36,7 @@ permalink: project
             and <a href="https://github.com/mmichaa/passafari.safariextension/">passafari</a> for Safari.
         <li>Support for the KeePassXC-Browser browser extension. It is available for
             <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/">Mozilla Firefox</a> and
-            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/iopaggbpplllidnfmcghoonnokmjoicf">Google Chrome / Chromium / Vivaldi</a>.
+            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk">Google Chrome / Chromium / Vivaldi</a>.
     </ul>
 
     <p> For a full list of new features and changes, have a look at the


### PR DESCRIPTION
Updates the URL's. The current URL's in the web page are old ones. Those links are already visible at keepassxc.org so this needs to be merged ASAP.