### PR TITLE
Add troubleshooting guide link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -363,7 +363,7 @@ title: Documentation and FAQ
             You can enable Browser Integration (KeePassXC-Browser) or Legacy Browser Integration (KeePassHTTP-Connector) from KeePassXC settings.
             A guide for KeePassHTTP-Connector is available <a href="https://github.com/smorks/keepasshttp-connector/blob/master/documentation/KeePassHttp-Connector.md">
             here</a>. See the page <a href="https://keepassxc.org/docs/keepassxc-browser-migration/">How to connect KeePassXC-Browser with KeePassXC</a> for more
-            detailed information for the new Browser Integration.
+            detailed information for the new Browser Integration. For troubleshooting see the following [wiki page](https://github.com/keepassxreboot/keepassxc-browser/wiki/Troubleshooting-guide).
         </dd>
 
         <dt id="faq-browser-diff"><a href="#faq-browser-diff">How does the new browser integration differ from the old?</a></dt>


### PR DESCRIPTION
Adds a link to the KeePassXC-Browser troubleshooting guide wiki page.