### PR TITLE
Download > Linux > Distribution packages: Add Solus

### DIFF
--- a/download.html
+++ b/download.html
@@ -158,7 +158,6 @@ permalink: download
                     </ul>
                 </div>
 
-
                 <div class="col-md-6">
                     <h5><i class="fl fl-centos" aria-hidden="true"></i> CentOS</h5>
                     <ul class="download-links">
@@ -178,6 +177,18 @@ permalink: download
                         </li>
                         <li>
                             <code>sudo zypper install keepassxc</code>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="col-md-6">
+                    <h5><i class="fl fl-solus" aria-hidden="true"></i> Solus</h5>
+                    <ul class="download-links">
+                        <li class="links">
+                            <a href="https://dev.getsol.us/source/keepassx/">Solus package</a>
+                        </li>
+                        <li>
+                            <code>sudo eopkg install keepassx</code>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Add Solus package in the linux distributions

- WARNING: The [version 0.14](https://github.com/lukas-w/font-logos/releases/tag/v0.14) the font-logos that was just released is required for the Solus logo
- The package name is keepassx instead of keepassxc, this is not a typo

Signed-off-by: Pierre-Yves <pyu@riseup.net>