### PR TITLE
Fixed FAQ dead link for Browser Integration docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -412,7 +412,7 @@ title: Documentation and FAQ
         <dd>
             You can enable Browser Integration (KeePassXC-Browser) or Legacy Browser Integration (KeePassHTTP-Connector) from KeePassXC settings.
             A guide for KeePassHTTP-Connector is available <a href="https://github.com/smorks/keepasshttp-connector/blob/master/documentation/KeePassHttp-Connector.md">
-            here</a>. See the page <a href="https://keepassxc.org/docs/keepassxc-browser-migration/">How to connect KeePassXC-Browser with KeePassXC</a> for more
+            here</a>. See the page <a href="https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_configure_keepassxc_browser">How to connect KeePassXC-Browser with KeePassXC</a> for more
             detailed information for the new Browser Integration. For troubleshooting see the following <a href="https://github.com/keepassxreboot/keepassxc-browser/wiki/Troubleshooting-guide">wiki page</a>.
         </dd>
 


### PR DESCRIPTION
The previous link "https://keepassxc.org/docs/keepassxc-browser-migration/" is currently returning 404. From my findings, the right location would now be
```
https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_configure_keepassxc_browser/
```