### PR TITLE
Tweak the blog teaser image

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ site.baseurl }}/"><object class="navbar-logo" type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg"></object> KeePassXC</a>
+      <a class="navbar-brand" href="{{ site.baseurl }}/"><img class="navbar-logo" src="{{ site.baseurl }}/images/keepassxc-logo.svg"> KeePassXC</a>
     </div>
     <div class="collapse navbar-collapse" id="navbar" aria-expanded="false">
         <ul class="nav navbar-nav navbar-right">

--- a/blog/_posts/2017-10-25-ubuntu-ppa.md
+++ b/blog/_posts/2017-10-25-ubuntu-ppa.md
@@ -5,12 +5,10 @@ date:   2017-10-25 14:51 +0200
 category: "Packages"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /blog/images/ubuntu-logo.png
+teaser_image_alt: "Ubuntu logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<img src="{{ site.baseurl }}/blog/images/ubuntu-logo.png" alt="Ubuntu logo">
-</div>
 
 With our AppImage and Snap release, KeePassXC runs on almost any desktop Linux platform
 today. While especially the AppImage is extremely versatile and portable, we

--- a/blog/_posts/2017-12-14-2.2.4-released.md
+++ b/blog/_posts/2017-12-14-2.2.4-released.md
@@ -5,12 +5,10 @@ date:   2017-12-14 10:00 +0100
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we announce the release of **KeePassXC 2.2.4**.
 

--- a/blog/_posts/2018-01-19-2.3-translations.md
+++ b/blog/_posts/2018-01-19-2.3-translations.md
@@ -5,12 +5,10 @@ date:   2018-01-19 22:13 +0100
 category: "Community Effort"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /blog/images/translations.png
+teaser_image_alt: "Translations"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<img src="{{ site.baseurl }}/blog/images/translations.png" alt="Translations">
-</div>
 
 The next big KeePassXC release is only weeks away and we are getting very anxious about releasing a first public
 beta version as soon as possible.

--- a/blog/_posts/2018-02-22-2.3-beta1-release.md
+++ b/blog/_posts/2018-02-22-2.3-beta1-release.md
@@ -5,12 +5,10 @@ date:   2018-02-22 13:44 +0100
 category: "Pre-Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we release a first **beta preview** of **KeePassXC 2.3.0**.
 

--- a/blog/_posts/2018-02-28-2.3-released.md
+++ b/blog/_posts/2018-02-28-2.3-released.md
@@ -5,12 +5,10 @@ date:   2018-02-28 03:00 +0100
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 After a short beta phase, we are proud to release **KeePassXC 2.3.0**.
 

--- a/blog/_posts/2018-03-07-2.3.1-released.md
+++ b/blog/_posts/2018-03-07-2.3.1-released.md
@@ -5,12 +5,10 @@ date:   2018-03-07 00:46 +0100
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 A week has gone by since our last big feature release and today we announce
 the first 2.3 maintenance release **KeePassXC 2.3.1**.

--- a/blog/_posts/2018-05-08-2.3.2-released.md
+++ b/blog/_posts/2018-05-08-2.3.2-released.md
@@ -5,12 +5,10 @@ date:   2018-05-08 23:13 -0500
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we announce the second 2.3 maintenance release **KeePassXC 2.3.2**.
 

--- a/blog/_posts/2018-05-09-2.3.3-released.md
+++ b/blog/_posts/2018-05-09-2.3.3-released.md
@@ -5,12 +5,10 @@ date:   2018-05-09 20:30 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we announce the third 2.3 maintenance release **KeePassXC 2.3.3**.
 

--- a/blog/_posts/2018-08-23-2.3.4-released.md
+++ b/blog/_posts/2018-08-23-2.3.4-released.md
@@ -5,12 +5,10 @@ date:   2018-08-23 21:32 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we announce another 2.3 maintenance release with **KeePassXC 2.3.4**.
 

--- a/blog/_posts/2019-03-19-2.4.0-released.md
+++ b/blog/_posts/2019-03-19-2.4.0-released.md
@@ -5,12 +5,10 @@ date:   2019-03-25 13:45 +0100
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 After two beta releases, today we are proud to release **KeePassXC 2.4.0**!
 

--- a/blog/_posts/2019-04-13-2.4.1-released.md
+++ b/blog/_posts/2019-04-13-2.4.1-released.md
@@ -5,12 +5,10 @@ date:   2019-04-13 02:30 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 We are happy to announce **KeePassXC 2.4.1**, the first maintenance release of the 2.4 series!
 

--- a/blog/_posts/2019-05-31-2.4.2-released.md
+++ b/blog/_posts/2019-05-31-2.4.2-released.md
@@ -5,12 +5,10 @@ date:   2019-05-31 21:30 +0200
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 We are happy to announce **KeePassXC 2.4.2**, the second maintenance release of the 2.4 series!
 

--- a/blog/_posts/2019-06-11-2.4.3-released.md
+++ b/blog/_posts/2019-06-11-2.4.3-released.md
@@ -5,12 +5,10 @@ date:   2019-06-11 22:00 +0200
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 We are happy to announce **KeePassXC 2.4.3**, the third maintenance release of the 2.4 series!
 

--- a/blog/_posts/2019-10-26-2.5.0-released.md
+++ b/blog/_posts/2019-10-26-2.5.0-released.md
@@ -5,12 +5,10 @@ date:   2019-10-26 23:55 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 A bit more than half a year has passed since the last major release of KeePassXC, so today we
 are very proud to announce **KeePassXC 2.5.0**.

--- a/blog/_posts/2019-11-11-2.5.1-released.md
+++ b/blog/_posts/2019-11-11-2.5.1-released.md
@@ -5,12 +5,10 @@ date:   2019-11-11 22:10 +0200
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing the first maintenance update for the 2.5 baseline, **KeePassXC 2.5.1**.
 

--- a/blog/_posts/2020-01-04-2.5.2-released.md
+++ b/blog/_posts/2020-01-04-2.5.2-released.md
@@ -5,12 +5,10 @@ date:   2020-01-04 17:00 +0200
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing the second maintenance update for the 2.5 baseline, **KeePassXC 2.5.2**.
 

--- a/blog/_posts/2020-01-19-2.5.3-released.md
+++ b/blog/_posts/2020-01-19-2.5.3-released.md
@@ -5,12 +5,10 @@ date:   2020-01-19 22:45 +0100
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-<object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing **KeePassXC 2.5.3**, the third maintenance update for KeePassXC 2.5.
 

--- a/blog/_posts/2020-04-09-2.5.4-released.md
+++ b/blog/_posts/2020-04-09-2.5.4-released.md
@@ -5,12 +5,10 @@ date:   2020-04-09 20:00 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-  <object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing **KeePassXC 2.5.4**, the fourth maintenance update for KeePassXC 2.5.
 

--- a/blog/_posts/2020-07-07-2.6.0-released.md
+++ b/blog/_posts/2020-07-07-2.6.0-released.md
@@ -5,12 +5,10 @@ date:   2020-07-07 22:30 +0200
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-  <object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we have released the long awaited **KeePassXC 2.6.0**. This release is the culmination of a year's worth of 
 effort from across our development team and dedicated contributors. With 2.6.0 comes a complete overhaul of the

--- a/blog/_posts/2020-08-19-2.6.1-released.md
+++ b/blog/_posts/2020-08-19-2.6.1-released.md
@@ -5,12 +5,10 @@ date:   2020-08-20 00:55 +0200
 category: "Releases"
 permalink: /:path/
 author: Janek Bevendorff
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-  <object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing the first 2.6 maintenance update, **KeePassXC 2.6.1**.
 

--- a/blog/_posts/2020-10-21-2.6.2-released.md
+++ b/blog/_posts/2020-10-21-2.6.2-released.md
@@ -5,12 +5,10 @@ date:   2020-10-21 20:00 -0400
 category: "Releases"
 permalink: /:path/
 author: Jonathan White
+teaser_image: /images/keepassxc-logo.svg
+teaser_image_alt: "KeePassXC logo"
 excerpt_separator: <!--more-->
 ---
-
-<div class="blog-teaser-img">
-  <object type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
-</div>
 
 Today we are releasing the second 2.6 maintenance update, **KeePassXC 2.6.2**.
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -30,6 +30,11 @@ layout: default
                     in category <em class="category"><i class="fa fa-tag" aria-hidden="true"></i> {{ post.category }}</em></p>
             </header>
             <div class="post-content">
+                {% if post.teaser_image %}
+                <div class="blog-teaser-img">
+                  <img src="{{ post.teaser_image | prepend: site.baseurl }}" alt="{{ post.teaser_image_alt }}">
+                </div>
+                {% endif %}
                 {{ post.excerpt  }}
                 <a href="{{ post.url }}">Read more…</a>
             </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
     <div class="container">
         <div class="row">
             <div id="logo" class="col-md-3 col-md-offset-1">
-                <object class="logo-graphic" type="image/svg+xml" data="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo"></object>
+                <img class="logo-graphic" src="{{ site.baseurl }}/images/keepassxc-logo.svg" alt="KeePassXC logo">
             </div>
             <div class="col-md-8">
                 <h4>KeePassXC</h4>


### PR DESCRIPTION
Hi!

I read the 2.6.2 release announcement in my RSS feed reader (I use inoreader.com). It looked a bit interesting to see that Chrome was warning about a Flash Player being included.

![Screen Shot 2020-10-21 at 19 35 48](https://user-images.githubusercontent.com/1991151/96821349-8892ff80-13dc-11eb-87df-43434065f786.png)

I took a look and saw that the KeePassXC logo svg file was being included with the `<object>` tag, and my feed reader is not including all of the attributes for whatever reason. But apparently the object tag is not really necessary for svg images these days. https://stackoverflow.com/questions/4476526/do-i-use-img-object-or-embed-for-svg-files

So I wanted to see if I could improve it. Unfortunately, I do not think just changing it to `<img>` will be very good for most feed readers since the CSS stylesheet from the website isn't included (I don't think there's a good way to include it either). It would look like this:

![Screen Shot 2020-10-21 at 19 56 10](https://user-images.githubusercontent.com/1991151/96821456-bd9f5200-13dc-11eb-833b-c8222d9b70c7.png)

Basically a big fat icon before any text. Not really an improvement.

So then I thought that the teaser image only makes a lot of sense on the list of blog posts on the website. It is not that necessary inside of the blog post itself. So I made the decision to just move it to front matter and only include it in `/blog/index.html`.

Please let me know what you think.