### PR TITLE
Upgrade cask installation command for brew 2.6.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -226,7 +226,7 @@ permalink: download
                         </a>
                     </li>
                     <li>
-                        <code>brew cask install keepassxc</code>
+                        <code>brew install --cask keepassxc</code>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
A quick PR to change the Homebrew cask upgrade for [the `2.6.0` upgrade](https://brew.sh/2020/12/01/homebrew-2.6.0/):

> All `brew cask` commands have been deprecated in favour of `brew` commands (with `--cask`) when necessary