### PR TITLE
fix blog atom feed 'self' url

### DIFF
--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -7,7 +7,7 @@ layout: none
         <title>{{ site.title | xml_escape }}</title>
         <description>{{ site.description | xml_escape }}</description>
         <link>{{ site.url }}{{ site.baseurl }}/</link>
-        <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
+        <atom:link href="{{ "/blog/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
         {% for post in site.posts limit:10 %}
         <item>
             <title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
The `self` link of the feed points to https://keepassxc.org/feed.xml which results in a 404.