### PR TITLE
Update link of winget-pkgs manifests to new structure

### DIFF
--- a/download.html
+++ b/download.html
@@ -377,7 +377,7 @@ permalink: download
                     </div>
                     <ul class="download-links">
                         <li class="links">
-                            <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/KeePassXCTeam/KeePassXC">
+                            <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/k/KeePassXCTeam/KeePassXC">
                                 Windows Package Manager Package
                             </a>
                         </li>


### PR DESCRIPTION
This inserts the recently added folder structure from the winget-pkgs manifest repository. 
The manifests are now grouped into subfolders named by the initial letters of the contained projects.
The KeePassXCTeam manifests therefore moved into the subfolder `k`.

Fixes #91