### PR TITLE
Use --user flag for flatpak install

### DIFF
--- a/download.html
+++ b/download.html
@@ -99,7 +99,7 @@ permalink: download
                             </a>
                         </li>
                         <li>
-                            <code>sudo flatpak install flathub org.keepassxc.KeePassXC</code>
+                            <code>flatpak install --user flathub org.keepassxc.KeePassXC</code>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
`sudo` is not required when installing a flatpak application using the
`--user` flag. I think we should recommend that by default.