### PR TITLE
Update version.yml (Flatpak)

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -7,7 +7,7 @@ stable:
       version: 2.7.1
       suffix:
     flatpak:
-      version: 2.6.6
+      version: 2.7.1
       suffix:
 
   mac:


### PR DESCRIPTION
Advertise v. 2.7.1 Stable for Flatpak on Linux.