### PR TITLE
Point winget to more specific package

### DIFF
--- a/download.html
+++ b/download.html
@@ -419,7 +419,7 @@ permalink: download
                             </a>
                         </li>
                         <li>
-                            <code>winget install keepassxc</code>
+                            <code>winget install KeePassXCTeam.KeePassXC</code>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Trying to install it with winget, you should point to the package from winget repository, not the windows store one (which has a separate link).

```
PS C:\Users\filip>  winget install keepassxc
The `msstore` source requires that you view the following agreements before using.
Terms of Transaction: https://aka.ms/microsoft-store-terms-of-transaction
The source requires the current machine's 2-letter geographic region to be sent to the backend service to function properly (ex. "US").

Do you agree to all the source agreements terms?
[Y] Yes  [N] No: y
Multiple packages found matching input criteria. Please refine the input.
Name      Id                      Source
-----------------------------------------
KeePassXC XP8K2L36VP0QMB          msstore
KeePassXC KeePassXCTeam.KeePassXC winget

PS C:\Users\filip>  winget install KeePassXCTeam.KeePassXC
Found KeePassXC [KeePassXCTeam.KeePassXC] Version 2.7.4
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/keepassxreboot/keepassxc/releases/download/2.7.4/KeePassXC-2.7.4-Win64.msi
  ██████████████████████████████  44.8 MB / 44.8 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```