### PR TITLE
Update links for VC++ redistributable package

### DIFF
--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -642,7 +642,7 @@ menu:
         <li>
             <a id="faq-ubuntushortcuts" class="uk-accordion-title" href="#faq-msvc-runtime-missing">I am getting "System Error: VCRUNTIME140_1.dll was not found" when starting KeePassXC. Why?</a>
             <div class="uk-accordion-content">
-                <p>This error indicates that you are missing the MSVC runtime library (Microsoft Visual C++ Redistributable). You can <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">download the latest version from Microsoft</a>. A download link can also be found on our <a href="{{< baseurl >}}download/#windows">downloads page</a>.
+                <p>This error indicates that you are missing the MSVC runtime library (Microsoft Visual C++ Redistributable). You can <a href="https://aka.ms/vc14/vc_redist.x64.exe">download the latest version from Microsoft</a>. A download link can also be found on our <a href="{{< baseurl >}}download/#windows">downloads page</a>.
             </div>
         </li>
     </ul>

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -102,7 +102,7 @@
                         Version {{ .Params.version.version }} &ndash;
                         <a href="https://github.com/keepassxreboot/keepassxc/releases">Older Releases</a>
                     </div>
-                    <div class="uk-margin-small uk-text-medium uk-text-bold">Requires <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">MSVC Redistributable</a></div>
+                    <div class="uk-margin-small uk-text-medium uk-text-bold">Requires <a href="https://aka.ms/vc14/vc_redist.x64.exe">MSVC Redistributable</a></div>
 
                     <div class="uk-text-small uk-margin-medium uk-margin-medium-bottom uk-text-muted">
                         <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;


### PR DESCRIPTION
The link for vs_redis in use pointed to `vs/17` which downloads v14.44.xxx, while the current release of redistributables is v14.50.xxx.
Not sure why `17` was left stale, with `14` and the newer `18` pointing to the v14.50 version 🤷 

In any case, the link used in the [MSDocs](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version) was [updated](https://github.com/MicrosoftDocs/cpp-docs/commits/f26307549cb61764515ee971f6ec1af5f85becfd/docs/windows/latest-supported-vc-redist.md) from `vs/17` to `vs/18` and finally to `vc14`. I assume following the renaming from "2015-2022 Redistributable" to just "v14 Redistributable".

This PR just reflects that and uses the new "[permalink](https://aka.ms/vc14/vc_redist.x64.exe)" to the latest supported version.